### PR TITLE
Add config property to adjust the length of task exec info name

### DIFF
--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -52,10 +52,12 @@ type Config struct {
 	JobManager              JobManagerConfig  `json:"jobmanager"`
 	TaskManager             TaskManagerConfig `json:"taskmanager"`
 	LogConfig               logs.LogConfig    `json:"logs"`
+	GeneratedNameMaxLength  *int              `json:generatedNameMaxLength pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
 }
 
 var (
-	defaultConfig = &Config{
+	generatedNameMaxLength = 50
+	defaultConfig          = &Config{
 		ServiceAccount: "default",
 		JobManager: JobManagerConfig{
 			Cpu:    resource.MustParse("4"),
@@ -66,6 +68,7 @@ var (
 			Memory:   resource.MustParse("4Gi"),
 			Replicas: 1,
 		},
+		GeneratedNameMaxLength: &generatedNameMaxLength,
 	}
 
 	flinkConfigSection = pluginsConfig.MustRegisterSubSection("flink", defaultConfig)

--- a/pkg/flink/config_test.go
+++ b/pkg/flink/config_test.go
@@ -38,6 +38,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, config.TaskManager.Replicas, 4)
 		assert.Equal(t, config.JobManager.Cpu, resource.MustParse("3.5"))
 		assert.Equal(t, config.ServiceAccount, "flink-service-account")
+		assert.Equal(t, *config.GeneratedNameMaxLength, 50)
 	})
 
 	t.Run("sets properties with no defaults", func(t *testing.T) {

--- a/pkg/flink/handler.go
+++ b/pkg/flink/handler.go
@@ -41,7 +41,10 @@ import (
 type flinkResourceHandler struct{}
 
 func (flinkResourceHandler) GetProperties() k8s.PluginProperties {
-	return k8s.PluginProperties{}
+	config := GetFlinkConfig()
+	return k8s.PluginProperties{
+		GeneratedNameMaxLength: config.GeneratedNameMaxLength,
+	}
 }
 
 // Creates a new Job that will execute the main container as well as any generated types the result from the execution.


### PR DESCRIPTION
Fixes #13 #11