### PR TITLE
Upgrade to go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spotify/flyte-flink-plugin
 
-go 1.16
+go 1.18
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.6.7


### PR DESCRIPTION
## Context
We are upgrading Flyte propeller and as part of this process we upgraded the golang version to 1.18. Therefore, it would be nice to upgrade it here too.