### PR TITLE
Skip FlinkCluster Defaults flag added

### DIFF
--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -21,12 +21,11 @@ import (
 
 // Config ... Flink-specific configs
 type Config struct {
-	DefaultFlinkCluster      flinkOp.FlinkCluster `json:"defaultFlinkCluster"`
-	SkipFlinkClusterDefaults bool                 `json:"skipFlinkClusterDefaults"`
-	FlinkPropertiesOverride  map[string]string    `json:"flinkPropertiesOverride" pflag:",Key value pairs of flink properties to be overridden in every FlinkJob"`
-	LogConfig                logs.LogConfig       `json:"logs"`
-	GeneratedNameMaxLength   *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
-	RemoteClusterConfig      ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
+	DefaultFlinkCluster     flinkOp.FlinkCluster `json:"defaultFlinkCluster"`
+	FlinkPropertiesOverride map[string]string    `json:"flinkPropertiesOverride" pflag:",Key value pairs of flink properties to be overridden in every FlinkJob"`
+	LogConfig               logs.LogConfig       `json:"logs"`
+	GeneratedNameMaxLength  *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
+	RemoteClusterConfig     ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
 }
 
 func GetFlinkConfig() *Config {

--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -21,11 +21,12 @@ import (
 
 // Config ... Flink-specific configs
 type Config struct {
-	DefaultFlinkCluster     flinkOp.FlinkCluster `json:"defaultFlinkCluster"`
-	FlinkPropertiesOverride map[string]string    `json:"flinkPropertiesOverride" pflag:",Key value pairs of flink properties to be overridden in every FlinkJob"`
-	LogConfig               logs.LogConfig       `json:"logs"`
-	GeneratedNameMaxLength  *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
-	RemoteClusterConfig     ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
+	DefaultFlinkCluster      flinkOp.FlinkCluster `json:"defaultFlinkCluster"`
+	SkipFlinkClusterDefaults bool                 `json:"skipFlinkClusterDefaults"`
+	FlinkPropertiesOverride  map[string]string    `json:"flinkPropertiesOverride" pflag:",Key value pairs of flink properties to be overridden in every FlinkJob"`
+	LogConfig                logs.LogConfig       `json:"logs"`
+	GeneratedNameMaxLength   *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
+	RemoteClusterConfig      ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
 }
 
 func GetFlinkConfig() *Config {

--- a/pkg/flink/resources.go
+++ b/pkg/flink/resources.go
@@ -339,9 +339,6 @@ func NewFlinkCluster(config *Config, taskCtx FlinkTaskContext) (*flinkOp.FlinkCl
 
 	// fill in defaults
 	resource := flinkOp.FlinkCluster(cluster)
-	if !config.SkipFlinkClusterDefaults {
-		resource.Default()
-	}
 
 	return &resource, nil
 }

--- a/pkg/flink/resources.go
+++ b/pkg/flink/resources.go
@@ -339,11 +339,8 @@ func NewFlinkCluster(config *Config, taskCtx FlinkTaskContext) (*flinkOp.FlinkCl
 
 	// fill in defaults
 	resource := flinkOp.FlinkCluster(cluster)
-	resource.Default()
-
-	err := resource.ValidateCreate()
-	if err != nil {
-		return nil, err
+	if !config.SkipFlinkClusterDefaults {
+		resource.Default()
 	}
 
 	return &resource, nil

--- a/pkg/flink/resources_test.go
+++ b/pkg/flink/resources_test.go
@@ -307,9 +307,7 @@ func TestPartialFlinkCluster(t *testing.T) {
 		},
 	}
 
-	config := &Config{
-		SkipFlinkClusterDefaults: true,
-	}
+	config := &Config{}
 
 	flinkCtx := FlinkTaskContext{
 		ClusterName: ClusterName("generated-name"),


### PR DESCRIPTION
This PR:

Removed code which defaults FlinkCluster spec values. This is needed to provide the option of adding a Mutation Webhook which can add additional defaults without them being overriden by the plugin. The Flink operator does default the values in the webhook.

Removed the validation logic for the FlinkCluster for the following reasons:
- Allows the plugin to apply a partially incomplete FlinkCluster spec to the K8s cluster and avoids throwing `Invalid` errors.
- Additionally, it removes duplicate validation logic as the Flink operator itself has a validation webhook.

Note: Alternatively, we could add an additional flag to `skipValidationLogic`
