### PR TITLE
Remove invalid access scope default

### DIFF
--- a/pkg/flink/constants.go
+++ b/pkg/flink/constants.go
@@ -47,7 +47,6 @@ var (
 			Spec: flinkOp.FlinkClusterSpec{
 				ServiceAccountName: &defaultServiceAccount,
 				JobManager: &flinkOp.JobManagerSpec{
-					AccessScope: "ClusterIP",
 					Resources: corev1.ResourceRequirements{
 						Limits: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU:    resource.MustParse("4"),


### PR DESCRIPTION
We can remove the default JobManager `accessScope` field and rely on the webhook to set the appropriate default value. 

Worth mentioning the current value `ClusterIP` is also invalid.