### PR TITLE
Use resource requests instead of limits

### DIFF
--- a/pkg/flink/config_test.go
+++ b/pkg/flink/config_test.go
@@ -33,9 +33,9 @@ func TestLoadConfig(t *testing.T) {
 		defaultCluster := flinkConfig.DefaultFlinkCluster.Spec
 		jm := defaultCluster.JobManager
 		tm := defaultCluster.TaskManager
-		assert.Equal(t, tm.Resources.Limits[corev1.ResourceCPU], resource.MustParse("4"))
-		assert.Equal(t, jm.Resources.Limits[corev1.ResourceMemory], resource.MustParse("4Gi"))
-		assert.Equal(t, tm.Resources.Limits[corev1.ResourceMemory], resource.MustParse("4Gi"))
+		assert.Equal(t, tm.Resources.Requests[corev1.ResourceCPU], resource.MustParse("4"))
+		assert.Equal(t, jm.Resources.Requests[corev1.ResourceMemory], resource.MustParse("4Gi"))
+		assert.Equal(t, tm.Resources.Requests[corev1.ResourceMemory], resource.MustParse("4Gi"))
 	})
 
 	t.Run("overrides defaults", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 		jm := defaultCluster.JobManager
 		tm := defaultCluster.TaskManager
 		assert.Equal(t, *tm.Replicas, int32(4))
-		assert.Equal(t, jm.Resources.Limits[corev1.ResourceCPU], resource.MustParse("3.5"))
+		assert.Equal(t, jm.Resources.Requests[corev1.ResourceCPU], resource.MustParse("3.5"))
 		assert.Equal(t, *flinkConfig.DefaultFlinkCluster.Spec.ServiceAccountName, "flink-service-account")
 		assert.Equal(t, *flinkConfig.GeneratedNameMaxLength, 50)
 	})

--- a/pkg/flink/constants.go
+++ b/pkg/flink/constants.go
@@ -49,7 +49,7 @@ var (
 				ServiceAccountName: &defaultServiceAccount,
 				JobManager: &flinkOp.JobManagerSpec{
 					Resources: corev1.ResourceRequirements{
-						Limits: map[corev1.ResourceName]resource.Quantity{
+						Requests: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
 						},
@@ -58,7 +58,7 @@ var (
 				TaskManager: &flinkOp.TaskManagerSpec{
 					Replicas: pointer.Int32(1),
 					Resources: corev1.ResourceRequirements{
-						Limits: map[corev1.ResourceName]resource.Quantity{
+						Requests: map[corev1.ResourceName]resource.Quantity{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
 						},

--- a/pkg/flink/resources.go
+++ b/pkg/flink/resources.go
@@ -153,13 +153,13 @@ func (fc *FlinkCluster) updateJobManagerSpec(taskCtx FlinkTaskContext) {
 
 	if cpu := jm.GetResource().GetCpu(); cpu != nil {
 		if quantity := resource.MustParse(cpu.GetString_()); !quantity.IsZero() {
-			out.Resources.Limits[corev1.ResourceCPU] = quantity
+			out.Resources.Requests[corev1.ResourceCPU] = quantity
 		}
 	}
 
 	if memory := jm.GetResource().GetMemory(); memory != nil {
 		if quantity := resource.MustParse(memory.GetString_()); !quantity.IsZero() {
-			out.Resources.Limits[corev1.ResourceMemory] = quantity
+			out.Resources.Requests[corev1.ResourceMemory] = quantity
 		}
 	}
 
@@ -188,13 +188,13 @@ func (fc *FlinkCluster) updateTaskManagerSpec(taskCtx FlinkTaskContext) {
 
 	if cpu := tm.GetResource().GetCpu(); cpu != nil {
 		if quantity := resource.MustParse(cpu.GetString_()); !quantity.IsZero() {
-			out.Resources.Limits[corev1.ResourceCPU] = quantity
+			out.Resources.Requests[corev1.ResourceCPU] = quantity
 		}
 	}
 
 	if memory := tm.GetResource().GetMemory(); memory != nil {
 		if quantity := resource.MustParse(memory.GetString_()); !quantity.IsZero() {
-			out.Resources.Limits[corev1.ResourceMemory] = quantity
+			out.Resources.Requests[corev1.ResourceMemory] = quantity
 		}
 	}
 

--- a/pkg/flink/testdata/config.yaml
+++ b/pkg/flink/testdata/config.yaml
@@ -38,7 +38,7 @@ plugins:
                   gsutil -m cp {{join .Artifacts " "}} lib &&
                   zip -r job.jar .
               resources:
-                limits:
+                requests:
                   cpu: "2"
                   memory: "1Gi"
         jobManager:
@@ -46,7 +46,7 @@ plugins:
           ingress:
             useTls: true
           resources:
-            limits:
+            requests:
               cpu: "3.5"
               memory: "4Gi"
           volumes:


### PR DESCRIPTION
The main reason for this is to avoid CPU throttling.