### PR TITLE
Rollback flytestdlib version to v1.0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.9.0
 	github.com/flyteorg/flyteidl v1.2.3
 	github.com/flyteorg/flyteplugins v1.0.18
-	github.com/flyteorg/flytestdlib v1.0.13
+	github.com/flyteorg/flytestdlib v1.0.11
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/flyteorg/flyteidl v1.2.3/go.mod h1:f0AFl7RFycH7+JLq2th0ReH7v+Xse+QTw4
 github.com/flyteorg/flyteplugins v1.0.18 h1:DOyxAFaS4luv7H9XRKUpHbO09imsG4LP8Du515FGXyM=
 github.com/flyteorg/flyteplugins v1.0.18/go.mod h1:ZbZVBxEWh8Icj1AgfNKg0uPzHHGd9twa4eWcY2Yt6xE=
 github.com/flyteorg/flytestdlib v1.0.0/go.mod h1:QSVN5wIM1lM9d60eAEbX7NwweQXW96t5x4jbyftn89c=
-github.com/flyteorg/flytestdlib v1.0.13 h1:mmU+k0Bc7HB5kWCgxoNJ9lZeD9tV1c7e5oCgyXKgO8c=
-github.com/flyteorg/flytestdlib v1.0.13/go.mod h1:nIBmBHtjTJvhZEn3e/EwVC/iMkR2tUX8hEiXjRBpH/s=
+github.com/flyteorg/flytestdlib v1.0.11 h1:f7B8x2/zMuimEVi4Jx0zqzvNhdi7aq7+ZWoqHsbp4F4=
+github.com/flyteorg/flytestdlib v1.0.11/go.mod h1:nIBmBHtjTJvhZEn3e/EwVC/iMkR2tUX8hEiXjRBpH/s=
 github.com/flyteorg/stow v0.3.3/go.mod h1:HBld7ud0i4khMHwJjkO8v+NSP7ddKa/ruhf4I8fliaA=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=
 github.com/flyteorg/stow v0.3.6/go.mod h1:5dfBitPM004dwaZdoVylVjxFT4GWAgI0ghAndhNUzCo=


### PR DESCRIPTION
```
go get github.com/flyteorg/flytestdlib@v1.0.11
go mod tidy
```

As part of the rollback that involved https://github.com/spotify/flyte-flink-plugin/pull/235