### PR TITLE
simplify task logs

### DIFF
--- a/pkg/flink/handler.go
+++ b/pkg/flink/handler.go
@@ -153,9 +153,6 @@ func (h flinkResourceHandler) OnAbort(ctx context.Context, tCtx pluginsCore.Task
 
 func flinkClusterTaskLogs(ctx context.Context, flinkCluster *flinkOp.FlinkCluster) ([]*core.TaskLog, error) {
 	var taskLogs []*core.TaskLog
-	jobManagerStatus := flinkCluster.Status.Components.JobManager
-	taskManagerStatus := flinkCluster.Status.Components.TaskManager
-	jobStatus := flinkCluster.Status.Components.Job
 
 	config := GetFlinkConfig()
 	p, err := logs.InitializeLogPlugins(&config.LogConfig)
@@ -167,38 +164,15 @@ func flinkClusterTaskLogs(ctx context.Context, flinkCluster *flinkOp.FlinkCluste
 		return taskLogs, nil
 	}
 
-	jobManagerLog, err := p.GetTaskLogs(tasklog.Input{
-		PodName:   jobManagerStatus.Name,
+	jobLog, err := p.GetTaskLogs(tasklog.Input{
+		PodName:   flinkCluster.Name,
 		Namespace: flinkCluster.Namespace,
-		LogName:   "(JobManager)",
+		LogName:   "(Job)",
 	})
 	if err != nil {
 		return nil, err
 	}
-	taskLogs = append(taskLogs, jobManagerLog.TaskLogs...)
-
-	taskManagerLog, err := p.GetTaskLogs(tasklog.Input{
-		PodName:   taskManagerStatus.Name,
-		Namespace: flinkCluster.Namespace,
-		LogName:   "(TaskManager)",
-	})
-	if err != nil {
-		return nil, err
-	}
-	taskLogs = append(taskLogs, taskManagerLog.TaskLogs...)
-
-	if jobStatus != nil {
-		jobLog, err := p.GetTaskLogs(tasklog.Input{
-			PodName:   jobStatus.SubmitterName,
-			Namespace: flinkCluster.Namespace,
-			LogName:   "(Job)",
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		taskLogs = append(taskLogs, jobLog.TaskLogs...)
-	}
+	taskLogs = append(taskLogs, jobLog.TaskLogs...)
 
 	return taskLogs, nil
 }


### PR DESCRIPTION
We want to display a single link at logs that contains cluster namespace and name.

This will also prevent missing pod name at log links in case of startup issues.