### PR TITLE
add custom non retry code

### DIFF
--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	GeneratedNameMaxLength  *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
 	RemoteClusterConfig     ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
 	NonRetryableExitCodes   []int32              `json:"nonRetryableExitCodes" pfFlag:"Defines which job submitter exit codes should not be retried"`
-	NonRetryableFlyteCode   string               `json:"nonRetryableFlyteCode" pfFlag:"Defines which code should be returned in case of nonRetryable exit codes"`
+	NonRetryableFlyteCode   string               `json:"nonRetryableFlyteCode,omitempty" pfFlag:"Defines which code should be returned in case of nonRetryable exit codes"`
 }
 
 func GetFlinkConfig() *Config {

--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	GeneratedNameMaxLength  *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
 	RemoteClusterConfig     ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
 	NonRetryableExitCodes   []int32              `json:"nonRetryableExitCodes" pfFlag:"Defines which job submitter exit codes should not be retried"`
+	NonRetryableFlyteCode   string               `json:"nonRetryableFlyteCode" pfFlag:"Defines which code should be returned in case of nonRetryable exit codes"`
 }
 
 func GetFlinkConfig() *Config {

--- a/pkg/flink/config.go
+++ b/pkg/flink/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	GeneratedNameMaxLength  *int                 `json:"generatedNameMaxLength" pflag:"Specifies the length of TaskExecutionID generated name. default: 50"`
 	RemoteClusterConfig     ClusterConfig        `json:"remoteClusterConfig" pflag:"Configuration of remote K8s cluster for array jobs"`
 	NonRetryableExitCodes   []int32              `json:"nonRetryableExitCodes" pfFlag:"Defines which job submitter exit codes should not be retried"`
-	NonRetryableFlyteCode   string               `json:"nonRetryableFlyteCode,omitempty" pfFlag:"Defines which code should be returned in case of nonRetryable exit codes"`
+	NonRetryableFlyteCode   *string              `json:"nonRetryableFlyteCode,omitempty" pfFlag:"Defines which code should be returned in case of nonRetryable exit codes"`
 }
 
 func GetFlinkConfig() *Config {

--- a/pkg/flink/constants.go
+++ b/pkg/flink/constants.go
@@ -15,6 +15,7 @@
 package flink
 
 import (
+	"github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"regexp"
 
 	pluginsConfig "github.com/flyteorg/flyteplugins/go/tasks/config"
@@ -42,7 +43,7 @@ var (
 	regexpFlinkClusterName      = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 	generatedNameMaxLength      = 50
 	nonRetryableExitCodes       = []int32{}
-	nonRetryableFlyteCode       = ""
+	nonRetryableFlyteCode       = errors.DownstreamSystemError
 	defaultServiceAccount       = "default"
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
@@ -67,7 +68,7 @@ var (
 		},
 		GeneratedNameMaxLength: &generatedNameMaxLength,
 		NonRetryableExitCodes:  nonRetryableExitCodes,
-		NonRetryableFlyteCode:  nonRetryableFlyteCode,
+		NonRetryableFlyteCode:  &nonRetryableFlyteCode,
 	}
 
 	flinkConfigSection = pluginsConfig.MustRegisterSubSection("flink", &defaultConfig)

--- a/pkg/flink/constants.go
+++ b/pkg/flink/constants.go
@@ -42,6 +42,7 @@ var (
 	regexpFlinkClusterName      = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 	generatedNameMaxLength      = 50
 	nonRetryableExitCodes       = []int32{}
+	nonRetryableFlyteCode       = ""
 	defaultServiceAccount       = "default"
 	defaultResourceRequirements = corev1.ResourceRequirements{
 		Limits: map[corev1.ResourceName]resource.Quantity{
@@ -66,6 +67,7 @@ var (
 		},
 		GeneratedNameMaxLength: &generatedNameMaxLength,
 		NonRetryableExitCodes:  nonRetryableExitCodes,
+		NonRetryableFlyteCode:  nonRetryableFlyteCode,
 	}
 
 	flinkConfigSection = pluginsConfig.MustRegisterSubSection("flink", &defaultConfig)

--- a/pkg/flink/handler.go
+++ b/pkg/flink/handler.go
@@ -249,14 +249,6 @@ func isSubmitterExitCodeRetryable(ctx context.Context, exitCode int32) bool {
 	return true
 }
 
-func getNonRetryableFlyteCode() string {
-	config := GetFlinkConfig()
-	if config.NonRetryableFlyteCode != "" {
-		return config.NonRetryableFlyteCode
-	}
-	return nonRetryableFlyteCode
-}
-
 func flinkClusterJobPhaseInfo(ctx context.Context, jobStatus *flinkOp.JobStatus, occurredAt time.Time, info *pluginsCore.TaskInfo) pluginsCore.PhaseInfo {
 	logger.Infof(ctx, "job_state: %s", jobStatus.State)
 
@@ -284,7 +276,7 @@ func flinkClusterJobPhaseInfo(ctx context.Context, jobStatus *flinkOp.JobStatus,
 			return pluginsCore.PhaseInfoRetryableFailure(errors.DownstreamSystemError, reason, info)
 		}
 		reason := fmt.Sprintf("Flink jobsubmitter exited with non-zero exit code: %v (non-retryable)", jobStatus.FailureReasons)
-		return pluginsCore.PhaseInfoFailure(getNonRetryableFlyteCode(), reason, info)
+		return pluginsCore.PhaseInfoFailure(nonRetryableFlyteCode, reason, info)
 	default:
 		msg := fmt.Sprintf("job id: %s with unknown state: %s", jobStatus.ID, jobStatus.State)
 		return pluginsCore.PhaseInfoFailure(errors.DownstreamSystemError, msg, info)

--- a/pkg/flink/handler.go
+++ b/pkg/flink/handler.go
@@ -254,7 +254,7 @@ func getNonRetryableFlyteCode() string {
 	if config.NonRetryableFlyteCode != "" {
 		return config.NonRetryableFlyteCode
 	}
-	return errors.DownstreamSystemError
+	return nonRetryableFlyteCode
 }
 
 func flinkClusterJobPhaseInfo(ctx context.Context, jobStatus *flinkOp.JobStatus, occurredAt time.Time, info *pluginsCore.TaskInfo) pluginsCore.PhaseInfo {

--- a/pkg/flink/handler.go
+++ b/pkg/flink/handler.go
@@ -249,6 +249,14 @@ func isSubmitterExitCodeRetryable(ctx context.Context, exitCode int32) bool {
 	return true
 }
 
+func getNonRetryableFlyteCode() string {
+	config := GetFlinkConfig()
+	if config.NonRetryableFlyteCode != "" {
+		return config.NonRetryableFlyteCode
+	}
+	return errors.DownstreamSystemError
+}
+
 func flinkClusterJobPhaseInfo(ctx context.Context, jobStatus *flinkOp.JobStatus, occurredAt time.Time, info *pluginsCore.TaskInfo) pluginsCore.PhaseInfo {
 	logger.Infof(ctx, "job_state: %s", jobStatus.State)
 
@@ -276,7 +284,7 @@ func flinkClusterJobPhaseInfo(ctx context.Context, jobStatus *flinkOp.JobStatus,
 			return pluginsCore.PhaseInfoRetryableFailure(errors.DownstreamSystemError, reason, info)
 		}
 		reason := fmt.Sprintf("Flink jobsubmitter exited with non-zero exit code: %v (non-retryable)", jobStatus.FailureReasons)
-		return pluginsCore.PhaseInfoFailure(errors.DownstreamSystemError, reason, info)
+		return pluginsCore.PhaseInfoFailure(getNonRetryableFlyteCode(), reason, info)
 	default:
 		msg := fmt.Sprintf("job id: %s with unknown state: %s", jobStatus.ID, jobStatus.State)
 		return pluginsCore.PhaseInfoFailure(errors.DownstreamSystemError, msg, info)


### PR DESCRIPTION
when the job fails with a non-retryable code we want to return a custom error code from Flyte. This error code can be used by external schedulers to make decisions on retry.